### PR TITLE
fix: use explicit NODE_AUTH_TOKEN for npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -21,4 +20,6 @@ jobs:
 
       - run: npm ci
 
-      - run: npm publish --provenance --access public
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
Remove `id-token: write` temporarily — setup-node was performing OIDC exchange and overwriting the static token. Explicit `NODE_AUTH_TOKEN` in step env ensures the secret is used. Once trusted publishing is properly configured on npmjs.com, we restore `--provenance` + `id-token: write`.