### PR TITLE
feat: restore OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,8 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      - run: npm install -g npm@latest
+
       - run: npm ci
 
       - run: npm publish --provenance --access public


### PR DESCRIPTION
Restore `id-token: write` + `--provenance`. No `NODE_AUTH_TOKEN` in step env — `setup-node` will exchange the GitHub OIDC token automatically. Requires trusted publisher configured on npmjs.com with no branch restriction (or `refs/tags/*` to match release triggers).